### PR TITLE
Feat/create advanced filter no options prompt

### DIFF
--- a/src/Filter/AdvancedFilter.tsx
+++ b/src/Filter/AdvancedFilter.tsx
@@ -56,7 +56,7 @@ export class AdvancedFilter extends React.Component<AdvancedFilterProps, {}> {
         );
       });
     }else{
-      tags.push(<div>No options.</div>)
+      tags.push(<div key={0}>No options.</div>)
     }
     return tags;
   }

--- a/src/Filter/AdvancedFilter.tsx
+++ b/src/Filter/AdvancedFilter.tsx
@@ -41,7 +41,7 @@ export class AdvancedFilter extends React.Component<AdvancedFilterProps, {}> {
   renderTags() {
     const tags: JSX.Element[] = [];
     let classname = "";
-    if (this.props.filterOptions) {
+    if (this.props.filterOptions.length > 0) {
       this.props.filterOptions.forEach((t, i) => {
         classname = t.isSelected ? "selected-button" : "";
 
@@ -55,6 +55,8 @@ export class AdvancedFilter extends React.Component<AdvancedFilterProps, {}> {
           </button>
         );
       });
+    }else{
+      tags.push(<div>No options.</div>)
     }
     return tags;
   }

--- a/stories/__snapshots__/stories.test.ts.snap
+++ b/stories/__snapshots__/stories.test.ts.snap
@@ -1456,7 +1456,11 @@ exports[`Storyshots Advanced Filter no options 1`] = `
     >
       <div
         className="filter-button-container"
-      />
+      >
+        <div>
+          No options.
+        </div>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
We're now displaying a message if there are no options under a filter category. That is how understood the task on tfs. This means that some categories can be empty and have no filters, for some reason. If the issue was regarding the case where no filter options are passed into the Advanced Filter at all then I can display a message for that too.