### PR TITLE
Feat/storybook debug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,19 @@
             "outFiles": [
                 "${workspaceFolder}/../lib/**/*.js"
             ]
+        },
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Debug Components",
+            "url": "http://localhost:6006",
+            "sourceMaps": true,
+            "sourceMapPathOverrides": {
+                "webpack:///./src/*": "${workspaceRoot}/src/*",
+            },
+            "skipFiles": [
+                "node_modules"
+            ]
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,13 +2,13 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "taskName": "install",
+            "label": "install",
             "type": "shell",
             "command": "npm install"
         },
 
         {
-            "taskName": "build",
+            "label": "build",
             "type": "shell",
             "command": "npm run storybook",
             "group": {


### PR DESCRIPTION
### Updates Made
I've altered the launch.json file so that we can debug components in Storybook from within VSCode; all it took was adding a new launch configuration and messing with `sourceMapPathOverrides`. I've also updated the tasks.json from using `taskName` to using `label`, as the docs recommend.

There are a couple things to be aware of, in order to use component debugging within VSCode:
1. Developers must install the [VSCode Chrome Debug Adapter](https://github.com/Microsoft/vscode-chrome-debug) to run the configuration.
2. The configuration does not run the build step at the same time as the debugger. Developers still have to run this task seperately.

### Contributing developer checklist
- [x] I've updated source branch with the latest changes from dev.
- [ ] ~~I've added/changed unit tests for components with functionality.~~
- [ ] ~~I've added/updated storybook for any component that I've changed.~~
- [ ] ~~I've reviewed each jsdoc header in regards to the changes that I've made and updated them.~~

### Reviewing developer checklist
- [x] I've pulled this branch to my local machine.
- [ ] ~~I've inspected the changes on storybook.~~
- [x] I've run the test suite and all tests have passed
