### PR TITLE
feat: add option in basic filter props to hide unclickable select msg

### DIFF
--- a/src/Filter/BasicFilter.tsx
+++ b/src/Filter/BasicFilter.tsx
@@ -122,15 +122,7 @@ export class BasicFilter extends React.Component<BasicFilterProps, {}> {
     const selected = filterOptions.find(fil => fil.isSelected === true);
     const selectedValue = selected ? selected.key : defaultValue;
 
-    let selectOptions: SelectOptionProps[] = [];
-    selectOptions.push({
-      disabled,
-      selected: selectedValue === defaultValue,
-      label: `Select ${label}`,
-      value: defaultValue
-    });
-
-    const filterSelectOptions = filterOptions.map(fo => {
+    const selectOptions = filterOptions.map(fo => {
       return {
         disabled,
         selected: selectedValue === fo.key,
@@ -139,7 +131,14 @@ export class BasicFilter extends React.Component<BasicFilterProps, {}> {
       };
     });
 
-    selectOptions = selectOptions.concat(filterSelectOptions);
+    if (!this.props.hideSelectMessage) {
+      selectOptions.splice(0, 0, {
+        disabled,
+        selected: selectedValue === defaultValue,
+        label: `Select ${label}`,
+        value: defaultValue
+      });
+    }
 
     return (
       <Select

--- a/src/Filter/FilterModels.ts
+++ b/src/Filter/FilterModels.ts
@@ -86,6 +86,7 @@ export interface FilterOptionModel {
 export interface BasicFilterCategoryModel extends FilterCategoryModel {
   optionType: OptionTypeModel;
   placeholderText?: string;
+  hideSelectMessage?: boolean;
 }
 
 export interface FilterCategoryModel {

--- a/src/Filter/__tests__/BasicFilterContainer.test.tsx
+++ b/src/Filter/__tests__/BasicFilterContainer.test.tsx
@@ -55,6 +55,17 @@ describe("BasicFilterContainer", () => {
     });
   });
 
+  it("hide select message if disabled", () => {
+    const gradeDropDownModel = mockBasicFilterCategories[0];
+    // tslint:disable-next-line:no-empty
+    const view = shallow(
+      <BasicFilter {...gradeDropDownModel} selectedHandler={() => {}} />
+    );
+    expect(view.findWhere(a => a.text().includes("Select")).length).toEqual(0);
+    expect(view).toMatchSnapshot();
+    const options = ["default", 7, 56, 960];
+  });
+
   it("can select radio button filter options", () => {
     const options = ["ELA", "Math"];
     let i = 0;

--- a/src/Filter/__tests__/BasicFilterContainer.test.tsx
+++ b/src/Filter/__tests__/BasicFilterContainer.test.tsx
@@ -57,8 +57,8 @@ describe("BasicFilterContainer", () => {
 
   it("hide select message if disabled", () => {
     const gradeDropDownModel = mockBasicFilterCategories[0];
-    // tslint:disable-next-line:no-empty
     const view = shallow(
+      // tslint:disable-next-line:no-empty
       <BasicFilter {...gradeDropDownModel} selectedHandler={() => {}} />
     );
     expect(view.findWhere(a => a.text().includes("Select")).length).toEqual(0);

--- a/src/Filter/__tests__/__snapshots__/BasicFilterContainer.test.tsx.snap
+++ b/src/Filter/__tests__/__snapshots__/BasicFilterContainer.test.tsx.snap
@@ -897,6 +897,50 @@ exports[`BasicFilterContainer expands the advanced filter 3`] = `
 </div>
 `;
 
+exports[`BasicFilterContainer hide select message if disabled 1`] = `
+<div
+  className="bf-selection"
+  id="grade-bf"
+>
+  <Component
+    className="input-sm med-text"
+    disabled={false}
+    key="Grade"
+    label="Grade"
+    onChange={[Function]}
+    options={
+      Array [
+        Object {
+          "disabled": false,
+          "label": "Select Grade",
+          "selected": true,
+          "value": "default",
+        },
+        Object {
+          "disabled": false,
+          "label": "Grades 3-5",
+          "selected": false,
+          "value": "7",
+        },
+        Object {
+          "disabled": false,
+          "label": "Grades 6-8",
+          "selected": false,
+          "value": "56",
+        },
+        Object {
+          "disabled": false,
+          "label": "High School",
+          "selected": false,
+          "value": "960",
+        },
+      ]
+    }
+    selected="default"
+  />
+</div>
+`;
+
 exports[`BasicFilterContainer resets filters on keyboard events 1`] = `
 <div
   className="bf-container section section-light bf-expanded"


### PR DESCRIPTION
### Updates Made
Add option in `BasicFilterCategoryModel` to hide that "select" message for dropdowns

### Contributing developer checklist
- [x] I've updated source branch with the latest changes from dev.
- [ ] I've added/changed unit tests for components with functionality.
- [ ] I've added/updated storybook for any component that I've changed.
- [ ] I've reviewed each jsdoc header in regards to the changes that I've made and updated them.

### Reviewing developer checklist
- [ ] I've pulled this branch to my local machine.
- [ ] I've inspected the changes on storybook.
- [ ] I've run the test suite and all tests have passed
