### PR TITLE
Feat/include rubric table styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7629,14 +7629,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7656,8 +7654,7 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",

--- a/src/Assets/Styles/sb-components.less
+++ b/src/Assets/Styles/sb-components.less
@@ -8,6 +8,9 @@
 @import "button";
 @import "modal";
 
+//## Pdf and Table styles
+@import "pdf";
+
 //## Components
 @import "about";
 @import "accessibility";


### PR DESCRIPTION
### Updates Made
The `pdf.less` file was not included in `sb-components.less` so it was not available when rendering rubric tables or modals correctly in IRV.

### Contributing developer checklist
- [x] I've updated source branch with the latest changes from dev.
- [x] I've added/changed unit tests for components with functionality.
- [x] I've added/updated storybook for any component that I've changed.
- [x] I've reviewed each jsdoc header in regards to the changes that I've made and updated them.

### Reviewing developer checklist
- [ ] I've pulled this branch to my local machine.
- [ ] I've inspected the changes on storybook.
- [ ] I've run the test suite and all tests have passed
