### PR TITLE
refactor: showless does not render if < 6 options

### DIFF
--- a/mocks/Accessibility/mocks.ts
+++ b/mocks/Accessibility/mocks.ts
@@ -740,3 +740,14 @@ export const allAccessibilityResourceGroups: AccResourceGroupModel[] = [
     ]
   }
 ];
+
+const accessibilityManyOptions: AccResourceGroupModel[] = [];
+allAccessibilityResourceGroups.forEach(s => {
+  accessibilityManyOptions.push(s);
+  if (s.label === "Accommodations") {
+    s.accessibilityResources.push(s.accessibilityResources[0]);
+    s.accessibilityResources.push(s.accessibilityResources[0]);
+  }
+});
+
+export const accessibilityManyOptionsMock: AccResourceGroupModel[] = accessibilityManyOptions;

--- a/src/Accessibility/AccessibilityModal.tsx
+++ b/src/Accessibility/AccessibilityModal.tsx
@@ -134,7 +134,7 @@ export class ItemAccessibilityModal extends React.Component<
     const resCount = resources.length;
     const isExpanded = (this.state.resourceTypeExpanded || {})[resourceType];
     if (!isExpanded) {
-      resources = resources.slice(0, 4);
+      resources = resources.slice(0, 6);
     }
 
     const dropdowns = resources.map(res => {
@@ -156,7 +156,7 @@ export class ItemAccessibilityModal extends React.Component<
     });
 
     let expandButton: JSX.Element | undefined;
-    if (resCount <= 4) {
+    if (resCount <= 6) {
       expandButton = undefined;
     } else if (isExpanded) {
       const ariaText = `Display fewer ${resourceType} options.`;

--- a/stories/Accessibility/Accessibility.storybook.tsx
+++ b/stories/Accessibility/Accessibility.storybook.tsx
@@ -4,7 +4,8 @@ import { storiesOf } from "@storybook/react";
 import {
   accessibilityModalProp,
   mockAccResourceGroups,
-  allAccessibilityResourceGroups
+  allAccessibilityResourceGroups,
+  accessibilityManyOptionsMock
 } from "@mocks/Accessibility/mocks";
 import { centerDecorator } from "../CenterDecorator";
 import { ItemAccessibilityModal } from "@src/index";
@@ -29,5 +30,12 @@ storiesOf("Accessibility Modal", module)
       {...accessibilityModalProp}
       showModal={true}
       accResourceGroups={[]}
+    />
+  ))
+  .add("Six options showing with out expand button.", () => (
+    <ItemAccessibilityModal
+      {...accessibilityModalProp}
+      showModal={true}
+      accResourceGroups={accessibilityManyOptionsMock}
     />
   ));

--- a/stories/Accessibility/__snapshots__/Accessibility.storybook.storyshot
+++ b/stories/Accessibility/__snapshots__/Accessibility.storybook.storyshot
@@ -1,5 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots Accessibility Modal Six options showing with out expand button. 1`] = `
+<div
+  className="section section-dark"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexFlow": "column nowrap",
+      "height": "100%",
+      "justifyContent": "center",
+      "paddingTop": "300px",
+      "width": "100%",
+    }
+  }
+>
+  <div>
+    <button
+      aria-label="Open Accessibility Modal"
+      className="btn btn-primary"
+      onClick={[Function]}
+      tabIndex={0}
+    >
+      <span
+        aria-hidden="true"
+        className="fa fa-caret-square-o-down"
+      />
+      Accessibility
+    </button>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Accessibility Modal few options hiding 1`] = `
 <div
   className="section section-dark"

--- a/stories/ItemPage/__snapshots__/ItemPage.storybook.storyshot
+++ b/stories/ItemPage/__snapshots__/ItemPage.storybook.storyshot
@@ -217,7 +217,7 @@ exports[`Storyshots Item Page Item Page with an item 1`] = `
       id="itemviewer-iframe"
       onLoad={[Function]}
       onLoadStart={[Function]}
-      src="http://ivs.smarterbalanced.org//items?ids=187-3000&isaap=TDS_ITM1%3BTDS_APC_SCRUBBER%3BTDS_SCNotepad%3BTDS_WL_Glossary%3BTDS_Highlight1%3BTDS_Dict_SD2%3BTDS_ExpandablePassages1%3BTDS_GN1%3BTDS_ST1%3BTDS_TH_TA%3BTDS_PS_L0%3BTDS_CCMagenta%3BTDS_Masking1%3BENU%3BTDS_ASL0%3BTDS_BT0%3BTDS_ClosedCap0%3BTDS_SLM0%3B&scrollToId=187-3000"
+      src="http://ivs.smarterbalanced.org//items?ids=187-3000&isaap=TDS_ITM1%3BTDS_APC_SCRUBBER%3BTDS_SCNotepad%3BTDS_WL_Glossary%3BTDS_Highlight1%3BTDS_Dict_SD2%3BTDS_ExpandablePassages1%3BTDS_GN1%3BTDS_ST1%3BTDS_TH_TA%3BTDS_PS_L0%3BTDS_CCMagenta%3BTDS_Masking1%3BENU%3BTDS_ASL0%3BTDS_BT0%3BTDS_ClosedCap0%3BTDS_SLM0%3BTDS_ASL0%3BTDS_ASL0%3B&scrollToId=187-3000"
       title="item viewer"
     />
   </div>


### PR DESCRIPTION
### Updates Made
Fixed the accessibility modal so that it will render 6 items with out showing the showmore button.

### Contributing developer checklist
- [x] I've updated source branch with the latest changes from dev.
- [x] I've added/changed unit tests for components with functionality.
- [x] I've added/updated storybook for any component that I've changed.
- [ ] I've reviewed each jsdoc header in regards to the changes that I've made and updated them.

### Reviewing developer checklist
- [x] I've pulled this branch to my local machine.
- [x] I've inspected the changes on storybook.
- [x] I've run the test suite and all tests have passed
