### PR TITLE
fix(itembank): remove extra scroll bar in the item viewer

### DIFF
--- a/src/Assets/Styles/item-frame.less
+++ b/src/Assets/Styles/item-frame.less
@@ -2,31 +2,31 @@
 @import "constants";
 
 .itemViewerFrame {
-    position: relative;
-    background-color: @sb-white;
-    overflow: auto;
-    -webkit-overflow-scrolling: touch;
-    height: 70vh;
-    width: 100%;
-    border-style: solid;
-    border-color: @grey-border-color;
-    border-width: 1px;
-    border-radius: @spacing-item;
-    -moz-box-shadow: @box-shadow;
-    -webkit-box-shadow: @box-shadow;
-    box-shadow: @box-shadow;
+  position: relative;
+  background-color: @sb-white;
+  overflow: hidden;
+  -webkit-overflow-scrolling: touch;
+  height: 70vh;
+  width: 100%;
+  border-style: solid;
+  border-color: @grey-border-color;
+  border-width: 1px;
+  border-radius: @spacing-item;
+  -moz-box-shadow: @box-shadow;
+  -webkit-box-shadow: @box-shadow;
+  box-shadow: @box-shadow;
 }
 
 .itemviewer-iframe {
-    height: 100%;
-    max-height: 99%;
-    width: 100%;
-    border: none;
+  height: 100%;
+  max-height: 99%;
+  width: 100%;
+  border: none;
 }
 
 .itemviewer-iframe-spinner {
-    position: absolute;
-    top: calc(~'50% - 60px');
-    left: calc(~'50% - 60px');
-    z-index: 1;
+  position: absolute;
+  top: calc(~"50% - 60px");
+  left: calc(~"50% - 60px");
+  z-index: 1;
 }


### PR DESCRIPTION
### Updates Made
The content overflow settings for the item viewer frame were changed to remove an extra scrollbar.

### Contributing developer checklist
- [x] I've updated source branch with the latest changes from dev.
- [x] I've added/changed unit tests for components with functionality.
- [x] I've added/updated storybook for any component that I've changed.
- [ ] I've reviewed each jsdoc header in regards to the changes that I've made and updated them.

### Reviewing developer checklist
- [ ] I've pulled this branch to my local machine.
- [ ] I've inspected the changes on storybook.
- [ ] I've run the test suite and all tests have passed
