### PR TITLE
Refactor/csv entry

### DIFF
--- a/src/CsvEntry/CsvEntry.tsx
+++ b/src/CsvEntry/CsvEntry.tsx
@@ -7,7 +7,8 @@ import {
   parseCsv,
   Accordion,
   validItemRevisionModel,
-  toCsvText
+  toCsvText,
+  toCsvModel
 } from "@src/index";
 
 export interface CsvEntryProps {
@@ -37,6 +38,20 @@ export class CsvEntry extends React.Component<CsvEntryProps, CsvEntryState> {
       csvInputValue,
       csvData
     };
+  }
+
+  componentWillReceiveProps(props: CsvEntryProps, state: CsvEntryState) {
+    if (
+      props.itemRows !== this.props.itemRows ||
+      this.props.itemRows.length !== props.itemRows.length
+    ) {
+      console.log("props recived\n\n\n");
+      const csvData = toCsvModel(props.itemRows);
+      console.log(props.itemRows);
+      const csvInputValue = toCsvText(csvData);
+      console.log(csvInputValue);
+      this.setState({ csvData, csvInputValue });
+    }
   }
 
   renderHelpText(): JSX.Element {

--- a/src/CsvEntry/CsvEntry.tsx
+++ b/src/CsvEntry/CsvEntry.tsx
@@ -45,11 +45,8 @@ export class CsvEntry extends React.Component<CsvEntryProps, CsvEntryState> {
       props.itemRows !== this.props.itemRows ||
       this.props.itemRows.length !== props.itemRows.length
     ) {
-      console.log("props recived\n\n\n");
       const csvData = toCsvModel(props.itemRows);
-      console.log(props.itemRows);
       const csvInputValue = toCsvText(csvData);
-      console.log(csvInputValue);
       this.setState({ csvData, csvInputValue });
     }
   }

--- a/src/CsvEntry/CsvEntry.tsx
+++ b/src/CsvEntry/CsvEntry.tsx
@@ -6,15 +6,15 @@ import {
   NamespaceModel,
   parseCsv,
   Accordion,
-  validItemRevisionModel
+  validItemRevisionModel,
+  toCsvText
 } from "@src/index";
 
 export interface CsvEntryProps {
-  csvText: string;
   namespaces: NamespaceModel[];
-  onCsvTextUpdate: (csvText: string) => void;
   onItemsUpdate: (items: ItemRevisionModel[]) => void;
   onApply: () => void;
+  itemRows: ItemRevisionModel[];
 }
 
 export interface CsvEntryState {
@@ -25,10 +25,17 @@ export interface CsvEntryState {
 export class CsvEntry extends React.Component<CsvEntryProps, CsvEntryState> {
   constructor(props: CsvEntryProps) {
     super(props);
-
+    const csvData: CsvRowModel[] = [];
+    let csvInputValue: string = "";
+    if (props.itemRows.length > 1) {
+      props.itemRows.forEach((item, index) => {
+        csvData.push({ ...item, index });
+      });
+      csvInputValue = toCsvText(csvData);
+    }
     this.state = {
-      csvInputValue: props.csvText,
-      csvData: []
+      csvInputValue,
+      csvData
     };
   }
 
@@ -89,8 +96,6 @@ export class CsvEntry extends React.Component<CsvEntryProps, CsvEntryState> {
     this.setState({
       csvInputValue: rawCsv
     });
-
-    this.props.onCsvTextUpdate(rawCsv);
   }
 
   handleCsvApply = () => {

--- a/src/CsvEntry/CsvEntryModels.ts
+++ b/src/CsvEntry/CsvEntryModels.ts
@@ -24,6 +24,17 @@ export function parseCsv(
   return data;
 }
 
+export function toCsvModel(items: ItemRevisionModel[]): CsvRowModel[] {
+  const csvData: CsvRowModel[] = [];
+  items.forEach((item, index) => {
+    if (item.itemKey) {
+      csvData.push({ ...item, index });
+    }
+  });
+
+  return csvData;
+}
+
 export function toCsvText(items: CsvRowModel[]): string {
   let csvString: string = "";
   items.forEach(item => {

--- a/src/CsvEntry/CsvEntryModels.ts
+++ b/src/CsvEntry/CsvEntryModels.ts
@@ -24,6 +24,20 @@ export function parseCsv(
   return data;
 }
 
+export function toCsvText(items: CsvRowModel[]): string {
+  let csvString: string = "";
+  items.forEach(item => {
+    if (item.itemKey) {
+      const itemString = item.bankKey
+        ? `${item.namespace},${item.bankKey},${item.itemKey},${item.section}\n`
+        : `${item.namespace},${item.itemKey},${item.section}\n`;
+      csvString = `${csvString}${itemString}`;
+    }
+  });
+
+  return csvString;
+}
+
 function parseLines(lines: string[], namespaces: NamespaceModel[]) {
   const data: CsvRowModel[] = [];
   let index = 0;

--- a/src/CsvEntry/__tests__/CsvEntry.test.tsx
+++ b/src/CsvEntry/__tests__/CsvEntry.test.tsx
@@ -24,18 +24,25 @@ const item2 = { ...item, bankKey: 2332, revision: "asdf" };
 
 const items: ItemRevisionModel[] = [item, item2];
 
-const csvEntryProps: CsvEntryProps = {
-  onCsvTextUpdate: onCsvTextUpdateMock,
-  onItemsUpdate: onItemsUpdateMock,
-  onApply: jest.fn()
-};
-
 const csvData1: CsvRowModel = {
+  ...item,
   index: 0
 };
 
 const csvData2: CsvRowModel = {
+  ...item2,
   index: 1
+};
+
+const csvData: CsvRowModel[] = [csvData1, csvData2];
+
+const csvEntryProps: CsvEntryProps = {
+  namespaces: [],
+  onItemsUpdate: (items: ItemRevisionModel[]) => {
+    const item = "";
+  },
+  onApply: jest.fn(),
+  itemRows: items
 };
 
 const csvEntryState: CsvEntryState = {

--- a/src/CsvEntry/__tests__/__snapshots__/CsvEntry.test.tsx.snap
+++ b/src/CsvEntry/__tests__/__snapshots__/CsvEntry.test.tsx.snap
@@ -169,6 +169,9 @@ exports[`CsvEntry matches snapshot 1`] = `
   <textarea
     className="csv-text-entry"
     onChange={[Function]}
+    value="undefined,3000,187,math
+undefined,2332,187,math
+"
   />
 </div>
 `;

--- a/src/ItemBank/ItemBankContainer.tsx
+++ b/src/ItemBank/ItemBankContainer.tsx
@@ -40,7 +40,6 @@ export interface ItemBankContainerState {
   aboutItemRevisionModel: Resource<AboutItemRevisionModel>;
   accResourceGroups: Resource<AccResourceGroupModel[]>;
   currentItem?: ItemRevisionModel;
-  csvText: string;
   items: ItemRevisionModel[];
   namespaces: Resource<NamespaceModel[]>;
   sections: Resource<SectionModel[]>;
@@ -69,7 +68,6 @@ export class ItemBankContainer extends React.Component<
     this.state = {
       currentItem,
       items,
-      csvText: "",
       aboutItemRevisionModel: { kind: "loading" },
       accResourceGroups: { kind: "loading" },
       namespaces: { kind: "loading" },
@@ -191,10 +189,6 @@ export class ItemBankContainer extends React.Component<
       );
     }
   }
-
-  handleUpdateCsvText = (csvText: string) => {
-    this.setState({ csvText });
-  };
 
   handleUpdateItems = (items: ItemRevisionModel[]) => {
     let currentItem: ItemRevisionModel | undefined;
@@ -433,7 +427,7 @@ export class ItemBankContainer extends React.Component<
   };
 
   renderItemBankEntry() {
-    const { namespaces, sections, items, csvText } = this.state;
+    const { namespaces, sections, items } = this.state;
     let content: JSX.Element | undefined;
 
     const namespacesContent = getResourceContent(namespaces);
@@ -441,10 +435,8 @@ export class ItemBankContainer extends React.Component<
     if (namespacesContent && sectionsContent) {
       content = (
         <ItemBankEntry
-          updateCsvText={this.handleUpdateCsvText}
           namespaces={namespacesContent}
           sections={sectionsContent}
-          csvText={csvText}
           items={items}
           deleteItem={this.deleteItem}
           clearItems={this.clearItems}

--- a/src/ItemBank/ItemBankEntry.tsx
+++ b/src/ItemBank/ItemBankEntry.tsx
@@ -9,13 +9,11 @@ import {
 } from "@src/index";
 
 export interface ItemBankEntryProps {
-  updateCsvText: (csvText: string) => void;
   deleteItem: (item: number) => void;
   clearItems: () => void;
   submitItems: (items: ItemRevisionModel[]) => void;
   namespaces: NamespaceModel[];
   sections: SectionModel[];
-  csvText: string;
   items: ItemRevisionModel[];
 }
 
@@ -53,7 +51,7 @@ export class ItemBankEntry extends React.Component<
   };
 
   renderCsvEntry() {
-    const { csvText, namespaces, submitItems } = this.props;
+    const { namespaces, submitItems } = this.props;
 
     return (
       <Accordion
@@ -64,11 +62,10 @@ export class ItemBankEntry extends React.Component<
         <div className="csv-entry-container section">
           <div className="csv-entry-wrapper">
             <CsvEntry
-              csvText={csvText}
               namespaces={namespaces}
-              onCsvTextUpdate={this.props.updateCsvText}
               onApply={this.onCsvApply}
               onItemsUpdate={submitItems}
+              itemRows={this.props.items}
             />
           </div>
         </div>

--- a/src/ItemBank/__tests__/__snapshots__/ItemBankEntry.test.tsx.snap
+++ b/src/ItemBank/__tests__/__snapshots__/ItemBankEntry.test.tsx.snap
@@ -14,6 +14,17 @@ exports[`ItemBankEntry matches snapshot 1`] = `
         className="csv-entry-wrapper"
       >
         <CsvEntry
+          itemRows={
+            Array [
+              Object {
+                "bankKey": 3000,
+                "isaap": "",
+                "itemKey": 187,
+                "revision": "asdge",
+                "section": "math",
+              },
+            ]
+          }
           namespaces={
             Array [
               Object {

--- a/src/ItemEntryTable/ItemEntryTable.tsx
+++ b/src/ItemEntryTable/ItemEntryTable.tsx
@@ -35,6 +35,18 @@ export class ItemEntryTable extends React.Component<
     };
   }
 
+  componentWillReceiveProps(
+    props: ItemEntryTableProps,
+    state: ItemEntryTableState
+  ) {
+    if (
+      this.props.itemRows !== props.itemRows ||
+      this.props.itemRows.length !== props.itemRows.length
+    ) {
+      this.setState({ itemRows: props.itemRows });
+    }
+  }
+
   handleRowUpdate(row: ItemRevisionModel, key: number) {
     this.setState((state: ItemEntryTableState) => {
       const itemRows = state.itemRows;

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,12 @@ export { parseQueryString } from "./Common/UrlParsing";
 // CSV Entry
 //
 export { CsvEntry, CsvEntryProps } from "./CsvEntry/CsvEntry";
-export { CsvRowModel, parseCsv, toCsvText } from "./CsvEntry/CsvEntryModels";
+export {
+  CsvRowModel,
+  parseCsv,
+  toCsvText,
+  toCsvModel
+} from "./CsvEntry/CsvEntryModels";
 
 //
 // DropDown Components and Models

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ export { parseQueryString } from "./Common/UrlParsing";
 // CSV Entry
 //
 export { CsvEntry, CsvEntryProps } from "./CsvEntry/CsvEntry";
-export { CsvRowModel, parseCsv } from "./CsvEntry/CsvEntryModels";
+export { CsvRowModel, parseCsv, toCsvText } from "./CsvEntry/CsvEntryModels";
 
 //
 // DropDown Components and Models


### PR DESCRIPTION
### Updates Made
This branch refactors the CSV entry tool to use the item revision model to construct the text rather than store the text in the state of the item bank container. Now the item rows are passed down to the csv component and the text is constructed. Once the new text is submitted the items are parsed from the text and passed out as item revision models to the item bank container. 

### Contributing developer checklist
- [x] I've updated source branch with the latest changes from dev.
- [x] I've added/changed unit tests for components with functionality.
- [x] I've added/updated storybook for any component that I've changed.
- [ ] I've reviewed each jsdoc header in regards to the changes that I've made and updated them.

### Reviewing developer checklist
- [ ] I've pulled this branch to my local machine.
- [ ] I've inspected the changes on storybook.
- [ ] I've run the test suite and all tests have passed
